### PR TITLE
Allow inline code tags to wrap

### DIFF
--- a/packages/eleventy/src/css/_code.scss
+++ b/packages/eleventy/src/css/_code.scss
@@ -1,5 +1,11 @@
 *:not(pre) > code {
-	white-space: nowrap;
+	background: var(--background-color);
+	border: 1px solid var(--color-highlight);
+	color: var(--color);
+	display: inline-block;
+	font-size: 0.8125em;
+	padding: 0 0.22rem;
+	white-space: wrap;
 }
 
 code,
@@ -25,14 +31,6 @@ pre {
 	word-break: normal;
 	word-spacing: normal;
 	word-wrap: break-word;
-}
-
-*:not(pre) > code {
-	background: var(--background-color);
-	border: 1px solid var(--color-highlight);
-	color: var(--color);
-	font-size: 0.8125em;
-	padding: 0.1rem 0.22rem 0.08rem;
 }
 
 .language-css > code,


### PR DESCRIPTION
Fixes issues with long inline code tags causing overflow on mobile.